### PR TITLE
Build source to ES5 in lib directory. Point package main file to lib.

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,11 +28,6 @@ Tests
 
 To run the tests `npm test`.
 
-Note that tests are breaking on Node v0.12.0 and IO.js v1.5.0. To run the tests,
-you will have to switch to v0.10.x
-
-This is a [known issue with Jest](https://github.com/facebook/jest/issues/267).
-
 How does it work?
 --------------------
 

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -6,14 +6,16 @@ var gulp       = require('gulp'),
     browserify = require('browserify'),
     watchify   = require('watchify'),
     babelify   = require('babelify'),
-    del        = require('del');
+    del        = require('del'),
+    babel      = require("gulp-babel");
 
 function _setupBrowserify(path, debug) {
   var b = browserify({
     entries: [path],
     transform: [babelify],
     debug: debug,
-    cache: {}, packageCache: {}, fullPaths: true
+    cache: {},
+    packageCache: {}
   });
 
   return b;
@@ -52,4 +54,11 @@ gulp.task('webserver', ['example:dev'], function() {
     .pipe(webserver({
       port: 8080
     }));
+});
+
+// build lib
+gulp.task("build:lib", function () {
+  return gulp.src("src/**/*.js")
+    .pipe(babel())
+    .pipe(gulp.dest("./lib/"));
 });

--- a/lib/TokenCell.js
+++ b/lib/TokenCell.js
@@ -1,0 +1,56 @@
+'use strict';
+
+Object.defineProperty(exports, '__esModule', {
+  value: true
+});
+
+function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { 'default': obj }; }
+
+var _react = require('react');
+
+var _react2 = _interopRequireDefault(_react);
+
+exports['default'] = _react2['default'].createClass({
+  displayName: 'TokenCell',
+
+  propTypes: {
+    textContent: _react2['default'].PropTypes.string
+  },
+
+  render: function render() {
+    var textContent = this.props.textContent;
+
+    if (!textContent || !textContent.trim()) {
+      return null;
+    }
+
+    return _react2['default'].createElement(
+      'div',
+      { className: 'rt-cell' },
+      _react2['default'].createElement(
+        'p',
+        { className: 'rt-cell__content' },
+        textContent.trim()
+      ),
+      _react2['default'].createElement(
+        'span',
+        { className: 'rt-cell__delete',
+          onClick: this._handleClick },
+        'x'
+      )
+    );
+  },
+
+  _handleClick: function _handleClick(evt) {
+    evt.preventDefault();
+    evt.stopPropagation();
+
+    var cell = this.getDOMNode(),
+        textContent = undefined;
+
+    textContent = cell.querySelector('.rt-cell__content').textContent;
+    this.props.removeToken(textContent);
+  }
+
+});
+module.exports = exports['default'];

--- a/lib/Tokenizer.js
+++ b/lib/Tokenizer.js
@@ -1,0 +1,117 @@
+'use strict';
+
+Object.defineProperty(exports, '__esModule', {
+  value: true
+});
+
+function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { 'default': obj }; }
+
+var _react = require('react');
+
+var _react2 = _interopRequireDefault(_react);
+
+var _TokenCell = require('./TokenCell');
+
+var _TokenCell2 = _interopRequireDefault(_TokenCell);
+
+var KEYS = {
+  BACKSPACE: 8,
+  TAB: 9,
+  COMMA: 188,
+  ENTER: 13
+};
+
+var SEPERATORS = [KEYS.TAB, KEYS.COMMA, KEYS.ENTER];
+
+exports['default'] = _react2['default'].createClass({
+  displayName: 'Tokenizer',
+
+  propTypes: {
+    tokens: _react2['default'].PropTypes.array,
+
+    tokenize: _react2['default'].PropTypes.func,
+    removeToken: _react2['default'].PropTypes.func
+  },
+
+  getDefaultProps: function getDefaultProps() {
+    return { tokens: [] };
+  },
+
+  getInitialState: function getInitialState() {
+    return { userInput: '' };
+  },
+
+  componentDidMount: function componentDidMount() {
+    this.refs.tokenInput.getDOMNode().focus();
+  },
+
+  componentDidUpdate: function componentDidUpdate() {
+    this.refs.tokenInput.getDOMNode().focus();
+  },
+
+  render: function render() {
+    var self = this,
+        tokens = self.props.tokens.map(function (token, index) {
+      return _react2['default'].createElement(_TokenCell2['default'], { key: index, textContent: token,
+        removeToken: self.props.removeToken });
+    });
+
+    return _react2['default'].createElement(
+      'div',
+      { className: 'rt-tokenizer' },
+      tokens,
+      _react2['default'].createElement('textarea', {
+        className: 'rt-tokenizer__user-input',
+        ref: 'tokenInput',
+        value: this.state.userInput,
+        onKeyDown: this._handleKeyDown,
+        onPaste: this._handlePaste,
+        onChange: this._handleChange })
+    );
+  },
+
+  _handleChange: function _handleChange(evt) {
+    this.setState({ userInput: evt.target.value });
+  },
+
+  _handleKeyDown: function _handleKeyDown(evt) {
+    var userInput = this.state.userInput;
+
+    if (SEPERATORS.indexOf(evt.which) !== -1) {
+      evt.preventDefault();
+
+      if (userInput.trim()) {
+        this.props.tokenize(userInput);
+        this.setState({ userInput: '' });
+      }
+    } else if (evt.which === KEYS.BACKSPACE) {
+      if (userInput.trim()) {
+        return;
+      }
+
+      var _parent = this.getDOMNode(),
+          cells = _parent.querySelectorAll('.rt-cell'),
+          lastChild = undefined,
+          textContent = undefined;
+
+      if (cells.length > 0) {
+        lastChild = cells[cells.length - 1];
+        textContent = lastChild.querySelector('.rt-cell__content').textContent;
+
+        this.props.removeToken(textContent);
+      }
+    }
+  },
+
+  _handlePaste: function _handlePaste(evt) {
+    evt.preventDefault();
+
+    var clipboard = evt.clipboardData,
+        data = clipboard.getData('text/plain'),
+        tokens = data.split("\n");
+
+    this.props.tokenize(tokens);
+  }
+
+});
+module.exports = exports['default'];

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "description": "A React.js component for tokenizing user input",
   "version": "0.1.0",
   "author": "Chen Zihui <hello@chenzihui.com>",
-  "main": "src/Tokenizer.js",
+  "main": "lib/Tokenizer.js",
   "repository": {
     "type": "git",
     "url": "https://github.com/chenzihui/react-tokenizer"
@@ -14,7 +14,7 @@
     "test": "jest"
   },
   "peerDependencies": {
-    "react": "^0.13.0"
+    "react": "^0.13.3"
   },
   "devDependencies": {
     "babel-jest": "^4.0.0",
@@ -22,12 +22,13 @@
     "browserify": "^9.0.3",
     "del": "^1.1.1",
     "gulp": "^3.8.11",
+    "gulp-babel": "^5.2.1",
     "gulp-plumber": "^0.6.6",
     "gulp-uglify": "^1.1.0",
     "gulp-util": "^3.0.4",
     "gulp-webserver": "^0.9.0",
-    "jest-cli": "^0.4.0",
-    "react-tools": "^0.13.0",
+    "jest-cli": "^0.5.10",
+    "react-tools": "^0.13.3",
     "vinyl-source-stream": "^1.0.0",
     "watchify": "^2.4.0"
   },


### PR DESCRIPTION
This adds a `build:lib` gulp task that transpiles the ES6 source to ES5 in the `/lib` directory, and updates the `main` file in `package.json` to point to the ES5 version, `lib/Tokenizer.js`. This allows projects that don't transpile ES6 libraries to also be able to install and use the react-tokenizer library.

Also, some packages have been updated so that running `npm install` in this project's path works with npm 3.3.6 and node 4.1.0.
